### PR TITLE
Update App Name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@
 version = 4
 
 [[package]]
-name = "acumen"
+name = "acuity"
 version = "0.1.0"
 dependencies = [
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "acumen"
+name = "acuity"
 version = "0.1.0"
 edition = "2024"
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-MIT License
+# MIT License
 
 Copyright (c) 2025- Travis Gibson
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Acumen Hardware Monitor
+# Acuity Hardware Monitor
 
 A WIP TUI-based hardware monitor, with HwInfo64 on Windows as inspiration.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -226,7 +226,7 @@ impl StatefulWidget for AppWidget {
     type State = App;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
-        let app_title = Line::from("Acumen Hardware Monitor");
+        let app_title = Line::from("Acuity Hardware Monitor");
         let app_version = Line::from("v0.0.1-dev");
         let app_block = Block::bordered()
             .title(app_title.centered())


### PR DESCRIPTION
"Acumen" is already taken on crates.io. Choosing "Acuity" for the new project name.